### PR TITLE
Implement message reply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
 
 ## Unversioned
 
+## v2.1.0
+
+- Minor: Implement `reply` in `TwitchIrcClient`
+
 ## v2.0.0
 
 - Updates to tokio v1.0 (#75)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,7 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
 
 ## Unversioned
 
-## v2.1.0
-
-- Minor: Implement `reply` in `TwitchIrcClient`
+- Minor: Added `say_in_response` and `reply_to_privmsg` methods to `TwitchIRCClient` (#84)
 
 ## v2.0.0
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,7 +1,6 @@
 mod event_loop;
 mod pool_connection;
 
-use crate::{client::event_loop::{ClientLoopCommand, ClientLoopWorker}, message::{IRCTags, PrivmsgMessage}};
 use crate::config::ClientConfig;
 use crate::error::Error;
 use crate::irc;
@@ -9,6 +8,10 @@ use crate::login::LoginCredentials;
 use crate::message::commands::ServerMessage;
 use crate::message::IRCMessage;
 use crate::transport::Transport;
+use crate::{
+    client::event_loop::{ClientLoopCommand, ClientLoopWorker},
+    message::{IRCTags, PrivmsgMessage},
+};
 use std::collections::HashSet;
 use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot};
@@ -126,7 +129,7 @@ impl<T: Transport, L: LoginCredentials> TwitchIRCClient<T, L> {
         // The prefixed "." prevents execution of commands
         self.privmsg(channel_login, format!(". {}", message)).await
     }
-    
+
     /// Replies to a given message in Twitch chat.
     ///
     /// Sends a message in the channel of the given message, tagging the original message and it's sender.
@@ -135,7 +138,7 @@ impl<T: Transport, L: LoginCredentials> TwitchIRCClient<T, L> {
             IRCTags::parse(&format!("reply-parent-msg-id={}", privmsg.message_id)),
             None,
             "PRIVMSG".to_string(),
-            vec![format!("#{}", privmsg.channel_login), message]
+            vec![format!("#{}", privmsg.channel_login), message],
         );
         self.send_message(irc_message).await
     }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -157,9 +157,9 @@ impl<T: Transport, L: LoginCredentials> TwitchIRCClient<T, L> {
     pub async fn reply_to_privmsg(
         &self,
         message: String,
-        reply_to: PrivmsgMessage,
+        reply_to: &PrivmsgMessage,
     ) -> Result<(), Error<T, L>> {
-        self.say_in_response(reply_to.channel_login, message, Some(reply_to.message_id))
+        self.say_in_response(reply_to.channel_login.clone(), message, Some(reply_to.message_id.clone()))
             .await
     }
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -159,8 +159,12 @@ impl<T: Transport, L: LoginCredentials> TwitchIRCClient<T, L> {
         message: String,
         reply_to: &PrivmsgMessage,
     ) -> Result<(), Error<T, L>> {
-        self.say_in_response(reply_to.channel_login.clone(), message, Some(reply_to.message_id.clone()))
-            .await
+        self.say_in_response(
+            reply_to.channel_login.clone(),
+            message,
+            Some(reply_to.message_id.clone()),
+        )
+        .await
     }
 
     /// Join the given Twitch channel (When a channel is joined, the client will receive messages

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,17 +1,15 @@
 mod event_loop;
 mod pool_connection;
 
+use crate::client::event_loop::{ClientLoopCommand, ClientLoopWorker};
 use crate::config::ClientConfig;
 use crate::error::Error;
 use crate::irc;
 use crate::login::LoginCredentials;
 use crate::message::commands::ServerMessage;
 use crate::message::IRCMessage;
+use crate::message::{IRCTags, PrivmsgMessage};
 use crate::transport::Transport;
-use crate::{
-    client::event_loop::{ClientLoopCommand, ClientLoopWorker},
-    message::{IRCTags, PrivmsgMessage},
-};
 use std::collections::HashSet;
 use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot};

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -151,7 +151,10 @@ impl<T: Transport, L: LoginCredentials> TwitchIRCClient<T, L> {
         self.send_message(irc_message).await
     }
 
-    /// Replies to a given Privmsg, tagging the original message and it's sender.
+    /// Replies to a given `PrivmsgMessage`, tagging the original message and it's sender.
+    ///
+    /// Similarly to `say()`, this method strips the message of executing commands, but does not filter out messages which are too long.
+    /// Refer to `say()` for the exact behaviour.
     pub async fn reply_to_privmsg(
         &self,
         message: String,

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -8,7 +8,10 @@ use crate::login::LoginCredentials;
 use crate::message::commands::ServerMessage;
 use crate::message::IRCMessage;
 use crate::transport::Transport;
-use crate::{client::event_loop::{ClientLoopCommand, ClientLoopWorker}, message::{IRCTags, PrivmsgMessage}};
+use crate::{
+    client::event_loop::{ClientLoopCommand, ClientLoopWorker},
+    message::{IRCTags, PrivmsgMessage},
+};
 use std::collections::HashSet;
 use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot};
@@ -129,9 +132,14 @@ impl<T: Transport, L: LoginCredentials> TwitchIRCClient<T, L> {
     /// Say a chat message in the given Twitch channel, but send it as a response to another message if `reply_to_id` is specified.
     ///
     /// Behaves the same as `say()` when `reply_to_id` is None, but tags the original message and it's sender if specified.
-    pub async fn say_in_response(&self, channel_login: String, message: String, reply_to_id: Option<String>) -> Result<(), Error<T, L>> {
+    pub async fn say_in_response(
+        &self,
+        channel_login: String,
+        message: String,
+        reply_to_id: Option<String>,
+    ) -> Result<(), Error<T, L>> {
         let mut tags = IRCTags::new();
-        
+
         if let Some(id) = reply_to_id {
             tags.0.insert("reply-parent-msg-id".to_string(), Some(id));
         }
@@ -143,12 +151,16 @@ impl<T: Transport, L: LoginCredentials> TwitchIRCClient<T, L> {
             vec![format!("#{}", channel_login), format!(". {}", message)], // The prefixed "." prevents commands from being executed
         );
         self.send_message(irc_message).await
-    
     }
 
     /// Replies to a given Privmsg, tagging the original message and it's sender.
-    pub async fn reply_to_privmsg(&self, message: String, reply_to: PrivmsgMessage) -> Result<(), Error<T, L>> {
-        self.say_in_response(reply_to.channel_login, message, Some(reply_to.message_id)).await
+    pub async fn reply_to_privmsg(
+        &self,
+        message: String,
+        reply_to: PrivmsgMessage,
+    ) -> Result<(), Error<T, L>> {
+        self.say_in_response(reply_to.channel_login, message, Some(reply_to.message_id))
+            .await
     }
 
     /// Join the given Twitch channel (When a channel is joined, the client will receive messages

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -8,10 +8,7 @@ use crate::login::LoginCredentials;
 use crate::message::commands::ServerMessage;
 use crate::message::IRCMessage;
 use crate::transport::Transport;
-use crate::{
-    client::event_loop::{ClientLoopCommand, ClientLoopWorker},
-    message::{IRCTags, PrivmsgMessage},
-};
+use crate::{client::event_loop::{ClientLoopCommand, ClientLoopWorker}, message::{IRCTags, PrivmsgMessage}};
 use std::collections::HashSet;
 use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot};
@@ -126,21 +123,32 @@ impl<T: Transport, L: LoginCredentials> TwitchIRCClient<T, L> {
     /// it will not be cut short or split into multiple messages (what happens is determined
     /// by the behaviour of the Twitch IRC server).
     pub async fn say(&self, channel_login: String, message: String) -> Result<(), Error<T, L>> {
-        // The prefixed "." prevents execution of commands
-        self.privmsg(channel_login, format!(". {}", message)).await
+        self.say_in_response(channel_login, message, None).await
     }
 
-    /// Replies to a given message in Twitch chat.
+    /// Say a chat message in the given Twitch channel, but send it as a response to another message if `reply_to_id` is specified.
     ///
-    /// Sends a message in the channel of the given message, tagging the original message and it's sender.
-    pub async fn reply(&self, privmsg: PrivmsgMessage, message: String) -> Result<(), Error<T, L>> {
+    /// Behaves the same as `say()` when `reply_to_id` is None, but tags the original message and it's sender if specified.
+    pub async fn say_in_response(&self, channel_login: String, message: String, reply_to_id: Option<String>) -> Result<(), Error<T, L>> {
+        let mut tags = IRCTags::new();
+        
+        if let Some(id) = reply_to_id {
+            tags.0.insert("reply-parent-msg-id".to_string(), Some(id));
+        }
+
         let irc_message = IRCMessage::new(
-            IRCTags::parse(&format!("reply-parent-msg-id={}", privmsg.message_id)),
+            tags,
             None,
             "PRIVMSG".to_string(),
-            vec![format!("#{}", privmsg.channel_login), message],
+            vec![format!("#{}", channel_login), format!(". {}", message)], // The prefixed "." prevents commands from being executed
         );
         self.send_message(irc_message).await
+    
+    }
+
+    /// Replies to a given Privmsg, tagging the original message and it's sender.
+    pub async fn reply_to_privmsg(&self, message: String, reply_to: PrivmsgMessage) -> Result<(), Error<T, L>> {
+        self.say_in_response(reply_to.channel_login, message, Some(reply_to.message_id)).await
     }
 
     /// Join the given Twitch channel (When a channel is joined, the client will receive messages


### PR DESCRIPTION
This pull request adds the ability to reply to a given `Privmsg` using the `reply-parent-msg-id` IRC tag.

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable