### PR TITLE
Fix metrics being initialized without all the labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
 
 ## Unversioned
 
+- Bugfix: Metrics are no longer initialized without all the labels, resulting in several metrics lingering around at zero forever.
+
 ## v2.2.0
 
 - Bugfix: Fixed fields on `UserAccessToken` being all private, preventing library users from constructing the type (as part of the `RefreshingLoginCredentials` system). (#101, #103)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
 
 ## Unversioned
 
-- Bugfix: Metrics are no longer initialized without all the labels, resulting in several metrics lingering around at zero forever.
+- Bugfix: Metrics are no longer initialized without all the labels, resulting in several metrics lingering around at zero forever. (#109)
 
 ## v2.2.0
 

--- a/src/client/event_loop.rs
+++ b/src/client/event_loop.rs
@@ -431,7 +431,7 @@ impl<T: Transport, L: LoginCredentials> ClientLoopWorker<T, L> {
                 // count up reconnects counter
                 #[cfg(feature = "metrics-collection")]
                 if let Some(ref metrics_identifier) = self.config.metrics_identifier {
-                    metrics::counter!("twitch_irc_reconnects", 1, "client" => metrics_identifier.clone().into_owned());
+                    metrics::counter!("twitch_irc_reconnects", 1, "client" => metrics_identifier.clone());
                 }
                 // also update twitch_irc_channels and twitch_irc_connections gauges
                 self.update_metrics();
@@ -482,13 +482,13 @@ impl<T: Transport, L: LoginCredentials> ClientLoopWorker<T, L> {
             metrics::gauge!(
                 "twitch_irc_connections",
                 num_initializing as f64,
-                "client" => metrics_identifier.clone().into_owned(),
+                "client" => metrics_identifier.clone(),
                 "state" => "initializing"
             );
             metrics::gauge!(
                 "twitch_irc_connections",
                 num_open as f64,
-                "client" => metrics_identifier.clone().into_owned(),
+                "client" => metrics_identifier.clone(),
                 "state" => "open"
             );
 
@@ -507,13 +507,13 @@ impl<T: Transport, L: LoginCredentials> ClientLoopWorker<T, L> {
             metrics::gauge!(
                 "twitch_irc_channels",
                 num_wanted as f64,
-                "client" => metrics_identifier.clone().into_owned(),
+                "client" => metrics_identifier.clone(),
                 "type" => "wanted"
             );
             metrics::gauge!(
                 "twitch_irc_channels",
                 num_server as f64,
-                "client" => metrics_identifier.clone().into_owned(),
+                "client" => metrics_identifier.clone(),
                 "type" => "server"
             );
         }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -60,27 +60,30 @@ impl<T: Transport, L: LoginCredentials> TwitchIRCClient<T, L> {
             metrics::register_counter!(
                 "twitch_irc_messages_received",
                 "Counts all incoming messages",
-                "client" => metrics_identifier.clone().into_owned()
+                "client" => metrics_identifier.clone(),
+                "command" => "PRIVMSG"
             );
             metrics::register_counter!(
                 "twitch_irc_messages_sent",
                 "Counts all outgoing messages",
-                "client" => metrics_identifier.clone().into_owned()
+                "client" => metrics_identifier.clone(),
+                "command" => "PING"
             );
             metrics::register_gauge!(
                 "twitch_irc_channels",
                 "Number of joined channels",
-                "client" => metrics_identifier.clone().into_owned()
+                "client" => metrics_identifier.clone()
             );
             metrics::register_gauge!(
                 "twitch_irc_connections",
                 "Number of connections in use by this client",
-                "client" => metrics_identifier.clone().into_owned()
+                "client" => metrics_identifier.clone(),
+                "type" => "server"
             );
             metrics::register_counter!(
                 "twitch_irc_reconnects",
                 "Counts up every time a connection in the connection pool fails unexpectedly",
-                "client" => metrics_identifier.clone().into_owned()
+                "client" => metrics_identifier.clone()
             );
         }
 

--- a/src/connection/event_loop.rs
+++ b/src/connection/event_loop.rs
@@ -182,7 +182,7 @@ impl<T: Transport, L: LoginCredentials> ConnectionLoopWorker<T, L> {
                             metrics::counter!(
                                 "twitch_irc_messages_received",
                                 1,
-                                "client" => metrics_identifier.clone().into_owned(),
+                                "client" => metrics_identifier.clone(),
                                 "command" => msg.command.clone()
                             )
                         }
@@ -496,7 +496,7 @@ impl<T: Transport, L: LoginCredentials> ConnectionLoopStateMethods<T, L>
             metrics::counter!(
                 "twitch_irc_messages_sent",
                 1,
-                "client" => metrics_identifier.clone().into_owned(),
+                "client" => metrics_identifier.clone(),
                 "command" => message.command.clone()
             )
         }


### PR DESCRIPTION
Also quick performance fix that removes into_owned() since metrics added a conversion for the stdlib Cow<'static, str>


Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable