### PR TITLE
src::lib.rs: docs fix; use ignore instead of no_run, due to build error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,7 +128,7 @@
 //! [`RefreshingLoginCredentials`](login/struct.RefreshingLoginCredentials.html), for example
 //! like this:
 //!
-//! ```no_run
+//! ```ignore
 //! use async_trait::async_trait;
 //! use twitch_irc::login::{RefreshingLoginCredentials, TokenStorage, UserAccessToken};
 //! use twitch_irc::ClientConfig;


### PR DESCRIPTION
Pull request checklist:

- [ ] `CHANGELOG.md` was updated, if applicable

@RAnders00 docs quick fix: using [ignore](https://doc.rust-lang.org/rustdoc/documentation-tests.html?highlight=ignore#attributes), instead of `no_run` due to compilation error while running tests
```

---- src/lib.rs - (line 131) stdout ----
error[E0432]: unresolved imports `twitch_irc::login::RefreshingLoginCredentials`, `twitch_irc::login::TokenStorage`, `twitch_irc::login::UserAccessToken`
 --> src/lib.rs:133:25
  |
5 | use twitch_irc::login::{RefreshingLoginCredentials, TokenStorage, UserAccessToken};
  |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^  ^^^^^^^^^^^^^^^ no `UserAccessToken` in `login`
  |                         |                           |
  |                         |                           no `TokenStorage` in `login`
  |                         no `RefreshingLoginCredentials` in `login`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0432`.
Couldn't compile the test.
```