### PR TITLE
Update metrics to 0.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## v3.1.0
+
+- Breaking: Updated `metrics` to version 0.17.
+
 ## v3.0.1
 
 - Bugfix: Fixed `FollowersOnlyMode` enum not being exported from the crate. (#135)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 Version numbers follow [Semantic Versioning](https://semver.org/).
 
-## v3.1.0
+## v4.0.0
 
 - Breaking: Updated `metrics` to version 0.17.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "twitch-irc"
 description = "Connect to Twitch chat from a Rust application."
 license = "MIT"
-version = "3.1.0"
+version = "4.0.0"
 authors = ["Ruben Anders <ruben.anders@robotty.de>"]
 repository = "https://github.com/robotty/twitch-irc-rs"
 edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "twitch-irc"
 description = "Connect to Twitch chat from a Rust application."
 license = "MIT"
-version = "3.0.1"
+version = "3.1.0"
 authors = ["Ruben Anders <ruben.anders@robotty.de>"]
 repository = "https://github.com/robotty/twitch-irc-rs"
 edition = "2018"
@@ -32,7 +32,7 @@ enum_dispatch = "0.3.5"
 futures-util = { version = "0.3.12", default-features = false, features = ["async-await", "sink", "std"] }
 itertools = "0.10.0"
 log = "0.4.13"
-metrics = { version = "0.16", optional = true }
+metrics = { version = "0.17", optional = true }
 reqwest = { version = "0.11", features = ["json"], optional = true }
 rustls-native-certs = { version = "0.5", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

Bumped the crate version to 3.1.0 because this is breaking and updated the changelog. 

I'm not expecting this to make its way into a release any time soon, but I had to do this locally, so I figured I might as well send over a PR for it. I'll be perfectly happy if this gets bundled with other changes and shipped out whenever the next release was supposed to happen.