### PR TITLE
Revert premature assignment of new version number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 Version numbers follow [Semantic Versioning](https://semver.org/).
 
-## v4.0.0
+## Unversioned
 
 - Breaking: Updated `metrics` to version 0.17.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "twitch-irc"
 description = "Connect to Twitch chat from a Rust application."
 license = "MIT"
-version = "4.0.0"
+version = "3.0.1"
 authors = ["Ruben Anders <ruben.anders@robotty.de>"]
 repository = "https://github.com/robotty/twitch-irc-rs"
 edition = "2018"


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable