### PR TITLE
Implement username fetching via the API in RefreshingLoginCredentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
 ## Unversioned
 
 - Breaking: Updated `metrics` to version 0.17.
+- Minor: Implement `Clone` for `RefreshingLoginCredentials`
 
 ## v3.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
 ## Unversioned
 
 - Breaking: Updated `metrics` to version 0.17.
-- Breaking: Implement user login fetching via the API when using `RefreshingLoginCredentials`.
+- Breaking: Implement user login fetching via the API when using `RefreshingLoginCredentials`. (#144)
 - Minor: Implement `Clone` for `RefreshingLoginCredentials`
 
 ## v3.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
 ## Unversioned
 
 - Breaking: Updated `metrics` to version 0.17.
+- Breaking: Implement user login fetching via the API when using `RefreshingLoginCredentials`.
 - Minor: Implement `Clone` for `RefreshingLoginCredentials`
 
 ## v3.0.1

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,30 +163,30 @@
 //!     }
 //! }
 //!
-//! let login_name = "your_bot_name".to_owned();
 //! // these credentials can be generated for your app at https://dev.twitch.tv/console/apps
+//! // the bot's username will be fecthed based on your access token
 //! let client_id = "rrbau1x7hl2ssz78nd2l32ns9jrx2w".to_owned();
 //! let client_secret = "m6nuam2b2zgn2fw8actt8hwdummz1g".to_owned();
 //! let storage = CustomTokenStorage { /* ... */ };
 //!
 //! let config = ClientConfig::new_simple(
-//!     RefreshingLoginCredentials::new(login_name, client_id, client_secret, storage)
+//!     RefreshingLoginCredentials::new(client_id, client_secret, storage)
 //! );
 //! // then create your client and use it
 //! # }
 //! ```
 //!
-//! `RefreshingLoginCredentials` just needs an implementation of `TokenStorage` that depends
+//! `RefreshingLoginCredentials` needs an implementation of `TokenStorage` that depends
 //! on your application, to retrieve the token or update it. For example, you might put the token
 //! in a config file you overwrite, some extra file for secrets, or a database.
 //!
-//! In addition to the structs/traits described above, the login module contains
-//! [`GetAccessTokenResponse`](crate::login::GetAccessTokenResponse) as a helper in case you
-//! implement the OAuth login process in your application and need to decode the response
-//! to `POST /oauth2/token` as part of the
-//! [OAuth authorization code flow](https://dev.twitch.tv/docs/authentication/getting-tokens-oauth#oauth-authorization-code-flow).
+//! In order to get started with `RefreshingLoginCredentials`, you need to have initial access
+//! and refresh tokens present in your storage. You can fetch these tokens using the
+//! [oauth authorization code flow](https://dev.twitch.tv/docs/authentication/getting-tokens-oauth#oauth-authorization-code-flow).
+//! There is also a [`GetAccessTokenResponse`](crate::login::GetAccessTokenResponse) helper struct
+//! that allows you to decode the `POST /oauth2/token` response as part of the authorization process.
 //! See the documentation on that type for details on usage and how to convert the decoded response
-//! to a `UserAccessToken`.
+//! to a `UserAccessToken` that you can then write to your `TokenStorage`.
 //!
 //! # Close the client
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,7 +164,7 @@
 //! }
 //!
 //! // these credentials can be generated for your app at https://dev.twitch.tv/console/apps
-//! // the bot's username will be fecthed based on your access token
+//! // the bot's username will be fetched based on your access token
 //! let client_id = "rrbau1x7hl2ssz78nd2l32ns9jrx2w".to_owned();
 //! let client_secret = "m6nuam2b2zgn2fw8actt8hwdummz1g".to_owned();
 //! let storage = CustomTokenStorage { /* ... */ };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,7 +182,7 @@
 //!
 //! In order to get started with `RefreshingLoginCredentials`, you need to have initial access
 //! and refresh tokens present in your storage. You can fetch these tokens using the
-//! [oauth authorization code flow](https://dev.twitch.tv/docs/authentication/getting-tokens-oauth#oauth-authorization-code-flow).
+//! [OAuth authorization code flow](https://dev.twitch.tv/docs/authentication/getting-tokens-oauth#oauth-authorization-code-flow).
 //! There is also a [`GetAccessTokenResponse`](crate::login::GetAccessTokenResponse) helper struct
 //! that allows you to decode the `POST /oauth2/token` response as part of the authorization process.
 //! See the documentation on that type for details on usage and how to convert the decoded response

--- a/src/login.rs
+++ b/src/login.rs
@@ -3,7 +3,6 @@
 use async_trait::async_trait;
 use std::convert::Infallible;
 use std::fmt::{Debug, Display};
-use std::sync::Arc;
 
 #[cfg(feature = "refreshing-token")]
 use {

--- a/src/login.rs
+++ b/src/login.rs
@@ -270,7 +270,10 @@ impl<S: TokenStorage> LoginCredentials for RefreshingLoginCredentials<S> {
                 // If no users are specified in the query, the API reponds with the user of the bearer token.
                 let user = users_response.data.into_iter().next().unwrap();
 
-                log::info!("Current username: {}", &user.login);
+                # TODO Have the fetched login name expire automatically to be resilient to bot's namechanges
+                # should then also automatically reconnect all connections with the new username, so the change
+                # will be a little more complex than just adding an expiry to this logic here.
+                log::info!("Fetched login name `{}` for provided auth token", &user.login);
 
                 *current_login = Some(user.login.clone());
 

--- a/src/login.rs
+++ b/src/login.rs
@@ -171,14 +171,29 @@ pub struct RefreshingLoginCredentials<S: TokenStorage> {
 #[cfg(feature = "refreshing-token")]
 impl<S: TokenStorage> RefreshingLoginCredentials<S> {
     /// Create new login credentials with a backing token storage.
-    pub fn new(
+    pub fn init(
+        client_id: String,
+        client_secret: String,
+        token_storage: S,
+    ) -> RefreshingLoginCredentials<S> {
+        RefreshingLoginCredentials::init_with_username(
+            None,
+            client_id,
+            client_secret,
+            token_storage,
+        )
+    }
+
+    /// Create new login credentials with a backing token storage and a predefined username.
+    pub fn init_with_username(
+        user_login: Option<String>,
         client_id: String,
         client_secret: String,
         token_storage: S,
     ) -> RefreshingLoginCredentials<S> {
         RefreshingLoginCredentials {
             http_client: reqwest::Client::new(),
-            user_login: Arc::new(Mutex::new(None)),
+            user_login: Arc::new(Mutex::new(user_login)),
             client_id,
             client_secret,
             token_storage: Arc::new(Mutex::new(token_storage)),

--- a/src/login.rs
+++ b/src/login.rs
@@ -260,8 +260,6 @@ impl<S: TokenStorage> LoginCredentials for RefreshingLoginCredentials<S> {
                     .await
                     .map_err(RefreshingLoginError::RefreshError)?;
 
-                log::info!("Fetching username: {}", response.status());
-
                 let users_response = response
                     .json::<UsersResponse>()
                     .await

--- a/src/login.rs
+++ b/src/login.rs
@@ -5,7 +5,13 @@ use std::convert::Infallible;
 use std::fmt::{Debug, Display};
 
 #[cfg(feature = "refreshing-token")]
-use {chrono::DateTime, chrono::Utc, std::time::Duration, thiserror::Error, tokio::sync::Mutex};
+use {
+    chrono::DateTime,
+    chrono::Utc,
+    std::{sync::Arc, time::Duration},
+    thiserror::Error,
+    tokio::sync::Mutex,
+};
 
 #[cfg(feature = "with-serde")]
 use {serde::Deserialize, serde::Serialize};
@@ -271,7 +277,10 @@ impl<S: TokenStorage> LoginCredentials for RefreshingLoginCredentials<S> {
                 // TODO Have the fetched login name expire automatically to be resilient to bot's namechanges
                 // should then also automatically reconnect all connections with the new username, so the change
                 // will be a little more complex than just adding an expiry to this logic here.
-                log::info!("Fetched login name `{}` for provided auth token", &user.login);
+                log::info!(
+                    "Fetched login name `{}` for provided auth token",
+                    &user.login
+                );
 
                 *current_login = Some(user.login.clone());
 

--- a/src/login.rs
+++ b/src/login.rs
@@ -5,10 +5,7 @@ use std::convert::Infallible;
 use std::fmt::{Debug, Display};
 
 #[cfg(feature = "refreshing-token")]
-use {chrono::DateTime, chrono::Utc, std::sync::Arc, std::time::Duration, thiserror::Error};
-
-#[cfg(feature = "refreshing-token")]
-use tokio::sync::Mutex;
+use {chrono::DateTime, chrono::Utc, std::time::Duration, thiserror::Error, tokio::sync::Mutex};
 
 #[cfg(feature = "with-serde")]
 use {serde::Deserialize, serde::Serialize};

--- a/src/login.rs
+++ b/src/login.rs
@@ -268,9 +268,9 @@ impl<S: TokenStorage> LoginCredentials for RefreshingLoginCredentials<S> {
                 // If no users are specified in the query, the API reponds with the user of the bearer token.
                 let user = users_response.data.into_iter().next().unwrap();
 
-                # TODO Have the fetched login name expire automatically to be resilient to bot's namechanges
-                # should then also automatically reconnect all connections with the new username, so the change
-                # will be a little more complex than just adding an expiry to this logic here.
+                // TODO Have the fetched login name expire automatically to be resilient to bot's namechanges
+                // should then also automatically reconnect all connections with the new username, so the change
+                // will be a little more complex than just adding an expiry to this logic here.
                 log::info!("Fetched login name `{}` for provided auth token", &user.login);
 
                 *current_login = Some(user.login.clone());

--- a/src/login.rs
+++ b/src/login.rs
@@ -170,7 +170,8 @@ pub struct RefreshingLoginCredentials<S: TokenStorage> {
 
 #[cfg(feature = "refreshing-token")]
 impl<S: TokenStorage> RefreshingLoginCredentials<S> {
-    /// Create new login credentials with a backing token storage.
+    /// Create new login credentials with a backing token storage. The username belonging to the
+    /// stored token is automatically fetched using the Twitch API when using this constructor.
     pub fn init(
         client_id: String,
         client_secret: String,
@@ -185,6 +186,9 @@ impl<S: TokenStorage> RefreshingLoginCredentials<S> {
     }
 
     /// Create new login credentials with a backing token storage and a predefined username.
+    /// If the username is predefined (pass `Some("the_username")` as `user_login`),
+    /// no API call will be made to the Twitch API to determine the username belonging to the token.
+    /// If the passed `user_login` is `None`, this constructor is functionally equivalent to [`RefreshingLoginCredentials::init`].
     pub fn init_with_username(
         user_login: Option<String>,
         client_id: String,

--- a/src/login.rs
+++ b/src/login.rs
@@ -156,9 +156,9 @@ pub trait TokenStorage: Debug + Send + 'static {
 pub struct RefreshingLoginCredentials<S: TokenStorage> {
     http_client: reqwest::Client,
     // TODO we could fetch this using the API, based on the token provided.
-    user_login: Arc<String>,
-    client_id: Arc<String>,
-    client_secret: Arc<String>,
+    user_login: String,
+    client_id: String,
+    client_secret: String,
     token_storage: Arc<Mutex<S>>,
 }
 
@@ -173,9 +173,9 @@ impl<S: TokenStorage> RefreshingLoginCredentials<S> {
     ) -> RefreshingLoginCredentials<S> {
         RefreshingLoginCredentials {
             http_client: reqwest::Client::new(),
-            user_login: Arc::new(user_login),
-            client_id: Arc::new(client_id),
-            client_secret: Arc::new(client_secret),
+            user_login,
+            client_id,
+            client_secret,
             token_storage: Arc::new(Mutex::new(token_storage)),
         }
     }
@@ -250,7 +250,7 @@ impl<S: TokenStorage> LoginCredentials for RefreshingLoginCredentials<S> {
         }
 
         Ok(CredentialsPair {
-            login: (*self.user_login).clone(),
+            login: self.user_login.clone(),
             token: Some(current_token.access_token.clone()),
         })
     }


### PR DESCRIPTION
This PR implements user login fetching via the API when using `RefreshingLoginCredentials`. It also changes the signature of `RefreshingLoginCredentials::new` to not accept a `user_login`, so it is a breaking change. This PR also includes/is based on #143.

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable