### PR TITLE
Spawn Tasks with a Name

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,6 +52,9 @@ jobs:
       run: cargo check --no-default-features --lib
     - name: Check (default features with serde)
       run: cargo check --features "with-serde" --lib
+    - name: Check (default features with tokio-tracing)
+      # See https://github.com/tokio-rs/console/#instrumenting-your-program
+      run: RUSTFLAGS="--cfg tokio_unstable" cargo check --features "tokio-tracing" --lib --examples
   docs:
     runs-on: ubuntu-latest
     container: rust:latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
 - Breaking: Updated `metrics` to version 0.17.
 - Breaking: Implement user login fetching via the API when using `RefreshingLoginCredentials`. (#144)
 - Minor: Implement `Clone` for `RefreshingLoginCredentials` (#143)
+- Minor: Added `tokio-tracing` feature that adds a name to tasks spawned by this library. (#145)
 
 ## v3.0.1
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,3 +74,5 @@ transport-ws-native-tls = ["transport-ws", "async-tungstenite/tokio-native-tls"]
 transport-ws-rustls-webpki-roots = ["transport-ws", "async-tungstenite/tokio-rustls"]
 metrics-collection = ["metrics"]
 with-serde = ["serde", "chrono/serde"]
+# TODO: update workflow
+tokio-tracing = ["tokio/tracing"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,5 +74,4 @@ transport-ws-native-tls = ["transport-ws", "async-tungstenite/tokio-native-tls"]
 transport-ws-rustls-webpki-roots = ["transport-ws", "async-tungstenite/tokio-rustls"]
 metrics-collection = ["metrics"]
 with-serde = ["serde", "chrono/serde"]
-# TODO: update workflow
 tokio-tracing = ["tokio/tracing"]

--- a/src/client/event_loop.rs
+++ b/src/client/event_loop.rs
@@ -5,11 +5,12 @@ use crate::config::ClientConfig;
 use crate::connection::event_loop::ConnectionLoopCommand;
 use crate::connection::{Connection, ConnectionIncomingMessage};
 use crate::error::Error;
+use crate::irc;
 use crate::login::LoginCredentials;
 use crate::message::commands::ServerMessage;
 use crate::message::{IRCMessage, JoinMessage, PartMessage};
+use crate::task::spawn_task;
 use crate::transport::Transport;
-use crate::{irc, spawn_task};
 use std::collections::{HashSet, VecDeque};
 use std::sync::{Arc, Weak};
 use tokio::sync::{mpsc, oneshot};
@@ -74,7 +75,7 @@ impl<T: Transport, L: LoginCredentials> ClientLoopWorker<T, L> {
             client_loop_tx,
             client_incoming_messages_tx,
         };
-        spawn_task!("twitch_irc::client::worker", worker.run());
+        spawn_task("twitch_irc::client::worker", worker.run());
     }
 
     async fn run(mut self) {
@@ -140,14 +141,14 @@ impl<T: Transport, L: LoginCredentials> ClientLoopWorker<T, L> {
         );
 
         // forward messages.
-        spawn_task!(
+        spawn_task(
             "twitch_irc::client::incoming_forward_task",
             ClientLoopWorker::run_incoming_forward_task(
                 connection_incoming_messages_rx,
                 connection_id,
                 self.client_loop_tx.clone(),
                 rx_kill_incoming,
-            )
+            ),
         );
 
         pool_conn

--- a/src/connection/event_loop.rs
+++ b/src/connection/event_loop.rs
@@ -1,12 +1,12 @@
 use crate::config::ClientConfig;
 use crate::connection::ConnectionIncomingMessage;
 use crate::error::Error;
-use crate::irc;
 use crate::login::{CredentialsPair, LoginCredentials};
 use crate::message::commands::ServerMessage;
 use crate::message::AsRawIRC;
 use crate::message::IRCMessage;
 use crate::transport::Transport;
+use crate::{irc, spawn_task};
 use enum_dispatch::enum_dispatch;
 use futures_util::{SinkExt, StreamExt};
 use itertools::Either;
@@ -91,11 +91,11 @@ impl<T: Transport, L: LoginCredentials> ConnectionLoopWorker<T, L> {
             config: Arc::clone(&config),
         };
 
-        tokio::spawn(ConnectionLoopWorker::run_init_task(
-            config,
-            connection_loop_tx,
-        ));
-        tokio::spawn(worker.run());
+        spawn_task!(
+            "twitch_irc::connection::init_task",
+            ConnectionLoopWorker::run_init_task(config, connection_loop_tx,)
+        );
+        spawn_task!("twitch_irc::connection::worker", worker.run());
     }
 
     async fn run_init_task(
@@ -135,7 +135,7 @@ impl<T: Transport, L: LoginCredentials> ConnectionLoopWorker<T, L> {
 
             // release the rate limit permit after the transport is connected and after
             // the specified time has elapsed.
-            tokio::spawn(async move {
+            spawn_task!("twitch_irc::client::release_rate_limit", async move {
                 tokio::time::sleep(config.new_connection_every).await;
                 drop(rate_limit_permit);
                 log::trace!("Successfully released permit after waiting specified duration.");
@@ -363,24 +363,33 @@ impl<T: Transport, L: LoginCredentials> ConnectionLoopStateMethods<T, L>
                 let (transport_incoming, transport_outgoing) = transport.split();
 
                 let (kill_incoming_loop_tx, kill_incoming_loop_rx) = oneshot::channel();
-                tokio::spawn(ConnectionLoopInitializingState::run_incoming_forward_task(
-                    transport_incoming,
-                    Weak::clone(&self.connection_loop_tx),
-                    kill_incoming_loop_rx,
-                ));
+                spawn_task!(
+                    "twitch_irc::client::incoming_forward_task",
+                    ConnectionLoopInitializingState::run_incoming_forward_task(
+                        transport_incoming,
+                        Weak::clone(&self.connection_loop_tx),
+                        kill_incoming_loop_rx,
+                    )
+                );
 
                 let (outgoing_messages_tx, outgoing_messages_rx) = mpsc::unbounded_channel();
-                tokio::spawn(ConnectionLoopInitializingState::run_outgoing_forward_task(
-                    transport_outgoing,
-                    outgoing_messages_rx,
-                    Weak::clone(&self.connection_loop_tx),
-                ));
+                spawn_task!(
+                    "twitch_irc::client::outgoing_forward_task",
+                    ConnectionLoopInitializingState::run_outgoing_forward_task(
+                        transport_outgoing,
+                        outgoing_messages_rx,
+                        Weak::clone(&self.connection_loop_tx),
+                    )
+                );
 
                 let (kill_pinger_tx, kill_pinger_rx) = oneshot::channel();
-                tokio::spawn(ConnectionLoopInitializingState::run_ping_task(
-                    Weak::clone(&self.connection_loop_tx),
-                    kill_pinger_rx,
-                ));
+                spawn_task!(
+                    "twitch_irc::client::ping_task",
+                    ConnectionLoopInitializingState::run_ping_task(
+                        Weak::clone(&self.connection_loop_tx),
+                        kill_pinger_rx,
+                    )
+                );
 
                 // transition our own state from Initializing to Open
                 #[cfg(feature = "metrics-collection")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,6 +234,7 @@ mod connection;
 mod error;
 pub mod login;
 pub mod message;
+mod task;
 pub mod transport;
 
 pub use client::TwitchIRCClient;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,11 +222,16 @@
 //!   documentation on `ClientConfig` for details.
 //! * **`with-serde`** pulls in `serde` v1.0 and adds `#[derive(Serialize, Deserialize)]` to many
 //!   structs.
+//! * **`tokio-tracing`** adds names to spawned tokio-tasks. This is useful when debugging through the [`tokio-console`][tokio-console].
+//!   When compiling, additional `rustflags` are **required**!
+//!   Take a look at the [`tokio-console` setup documentation][tokio-console-setup] for more info.
 //!
 //! By default, `transport-tcp` and `transport-tcp-native-tls` are enabled.
 //!
 //! [rustls]: https://github.com/ctz/rustls
 //! [mozilla-roots]: https://github.com/ctz/webpki-roots
+//! [tokio-console]: https://github.com/tokio-rs/console
+//! [tokio-console-setup]: https://github.com/tokio-rs/console/#instrumenting-your-program
 
 mod client;
 mod config;

--- a/src/task.rs
+++ b/src/task.rs
@@ -1,12 +1,23 @@
+use std::future::Future;
+use tokio::task::JoinHandle;
+
 /// Spawns a tokio task with a name.
 /// This is useful in the tokio-console.
-#[macro_export]
-macro_rules! spawn_task {
-    ($name:literal, $task:expr) => {
-        if cfg!(feature = "tokio-tracing") {
-            tokio::task::Builder::new().name($name).spawn($task)
-        } else {
-            tokio::spawn($task)
-        }
-    };
+#[cfg(feature = "tokio-tracing")]
+#[inline]
+pub fn spawn_task<T>(name: &str, future: T) -> JoinHandle<T::Output>
+where
+    T: Future + Send + 'static,
+    T::Output: Send + 'static,
+{
+    tokio::task::Builder::new().name(name).spawn(future)
+}
+#[cfg(not(feature = "tokio-tracing"))]
+#[inline]
+pub fn spawn_task<T>(_name: &str, future: T) -> JoinHandle<T::Output>
+where
+    T: Future + Send + 'static,
+    T::Output: Send + 'static,
+{
+    tokio::spawn(future)
 }

--- a/src/task.rs
+++ b/src/task.rs
@@ -1,0 +1,12 @@
+/// Spawns a tokio task with a name.
+/// This is useful in the tokio-console.
+#[macro_export]
+macro_rules! spawn_task {
+    ($name:literal, $task:expr) => {
+        if cfg!(feature = "tokio-tracing") {
+            tokio::task::Builder::new().name($name).spawn($task)
+        } else {
+            tokio::spawn($task)
+        }
+    };
+}


### PR DESCRIPTION
This PR adds a name to tasks that are spawned (if `tokio-tracing` is enabled). 

This is useful when viewing tasks in the [`tokio-console`](https://github.com/tokio-rs/console). Otherwise only the file and line the task was spawned at is listed.

<details>
<summary>Example View of the Console</summary>

![view of the tokio-console](https://i.imgur.com/m8a5mKD.png)
</details>

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Update `workflows/rust.yml`