### PR TITLE
Treat emote set ids properly (as strings)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
 
 ## Unversioned
 
-- Breaking: Handle `emote_sets` as `String`s since not all of them are in fact `u64`s
+- Breaking: Handle `emote_sets` as `String`s since not all of them are in fact `u64`s (#162)
 
 ## v4.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## Unversioned
+
+- Breaking: Handle `emote_sets` as `String`s since not all of them are in fact `u64`s
+
 ## v4.0.0
 
 - Breaking: Updated `metrics` to version 0.18. (#146)

--- a/src/message/commands/globaluserstate.rs
+++ b/src/message/commands/globaluserstate.rs
@@ -90,7 +90,10 @@ mod tests {
                 user_name: "randers".to_owned(),
                 badge_info: vec![],
                 badges: vec![],
-                emote_sets: vec!["0", "42", "237"].into_iter().map(|s| s.to_owned()).collect(),
+                emote_sets: vec!["0", "42", "237"]
+                    .into_iter()
+                    .map(|s| s.to_owned())
+                    .collect(),
                 name_color: Some(RGBColor {
                     r: 0x19,
                     g: 0xE6,

--- a/src/message/commands/globaluserstate.rs
+++ b/src/message/commands/globaluserstate.rs
@@ -29,7 +29,7 @@ pub struct GlobalUserStateMessage {
     pub badge_info: Vec<Badge>,
     /// List of badges the logged in user has in all channels.
     pub badges: Vec<Badge>,
-    /// List of emote set IDs the logged in user has available. This always contains at least 0.
+    /// List of emote set IDs the logged in user has available. This always contains at least one entry ("0").
     pub emote_sets: HashSet<String>,
     /// What name color the logged in user has chosen. The same color is used in all channels.
     pub name_color: Option<RGBColor>,

--- a/src/message/commands/globaluserstate.rs
+++ b/src/message/commands/globaluserstate.rs
@@ -90,7 +90,7 @@ mod tests {
                 user_name: "randers".to_owned(),
                 badge_info: vec![],
                 badges: vec![],
-                emote_sets: vec!["0", "42", "237"].into_iter().map(|s| s.to_string()).collect(),
+                emote_sets: vec!["0", "42", "237"].into_iter().map(|s| s.to_owned()).collect(),
                 name_color: Some(RGBColor {
                     r: 0x19,
                     g: 0xE6,
@@ -140,7 +140,7 @@ mod tests {
                 user_name: "randers811".to_owned(),
                 badge_info: vec![],
                 badges: vec![],
-                emote_sets: HashSet::from_iter(vec!["0".to_string()]),
+                emote_sets: HashSet::from_iter(vec!["0".to_owned()]),
                 name_color: None,
                 source: irc_message
             }

--- a/src/message/commands/globaluserstate.rs
+++ b/src/message/commands/globaluserstate.rs
@@ -30,7 +30,7 @@ pub struct GlobalUserStateMessage {
     /// List of badges the logged in user has in all channels.
     pub badges: Vec<Badge>,
     /// List of emote set IDs the logged in user has available. This always contains at least 0.
-    pub emote_sets: HashSet<u64>,
+    pub emote_sets: HashSet<String>,
     /// What name color the logged in user has chosen. The same color is used in all channels.
     pub name_color: Option<RGBColor>,
 
@@ -90,7 +90,7 @@ mod tests {
                 user_name: "randers".to_owned(),
                 badge_info: vec![],
                 badges: vec![],
-                emote_sets: vec![0, 42, 237].into_iter().collect(),
+                emote_sets: vec!["0", "42", "237"].into_iter().map(|s| s.to_string()).collect(),
                 name_color: Some(RGBColor {
                     r: 0x19,
                     g: 0xE6,
@@ -140,7 +140,7 @@ mod tests {
                 user_name: "randers811".to_owned(),
                 badge_info: vec![],
                 badges: vec![],
-                emote_sets: HashSet::from_iter(vec![0]),
+                emote_sets: HashSet::from_iter(vec!["0".to_string()]),
                 name_color: None,
                 source: irc_message
             }

--- a/src/message/commands/mod.rs
+++ b/src/message/commands/mod.rs
@@ -299,9 +299,7 @@ impl IRCMessageParseExt for IRCMessage {
         if src.is_empty() {
             Ok(HashSet::new())
         } else {
-            let emote_sets: HashSet<String> = src.split(",").map(|s| s.to_owned()).collect();
-
-            Ok(emote_sets)
+            Ok(src.split(",").map(|s| s.to_owned()).collect())
         }
     }
 

--- a/src/message/commands/mod.rs
+++ b/src/message/commands/mod.rs
@@ -299,12 +299,7 @@ impl IRCMessageParseExt for IRCMessage {
         if src.is_empty() {
             Ok(HashSet::new())
         } else {
-            let mut emote_sets = HashSet::new();
-
-            for emote_set in src.split(',') {
-                emote_sets
-                    .insert(emote_set.to_owned());
-            }
+            let emote_sets: HashSet<String> = src.split(",").map(|s| s.to_owned()).collect();
 
             Ok(emote_sets)
         }

--- a/src/message/commands/mod.rs
+++ b/src/message/commands/mod.rs
@@ -117,7 +117,7 @@ trait IRCMessageParseExt {
     fn try_get_emote_sets(
         &self,
         tag_key: &'static str,
-    ) -> Result<HashSet<u64>, ServerMessageParseError>;
+    ) -> Result<HashSet<String>, ServerMessageParseError>;
     fn try_get_badges(&self, tag_key: &'static str) -> Result<Vec<Badge>, ServerMessageParseError>;
     fn try_get_color(
         &self,
@@ -293,7 +293,7 @@ impl IRCMessageParseExt for IRCMessage {
     fn try_get_emote_sets(
         &self,
         tag_key: &'static str,
-    ) -> Result<HashSet<u64>, ServerMessageParseError> {
+    ) -> Result<HashSet<String>, ServerMessageParseError> {
         let src = self.try_get_nonempty_tag_value(tag_key)?;
 
         if src.is_empty() {
@@ -303,9 +303,7 @@ impl IRCMessageParseExt for IRCMessage {
 
             for emote_set in src.split(',') {
                 emote_sets
-                    .insert(u64::from_str(&emote_set).map_err(|_| {
-                        MalformedTagValue(self.to_owned(), tag_key, src.to_owned())
-                    })?);
+                    .insert(emote_set.to_owned());
             }
 
             Ok(emote_sets)

--- a/src/message/commands/userstate.rs
+++ b/src/message/commands/userstate.rs
@@ -30,7 +30,7 @@ pub struct UserStateMessage {
     /// List of badges the logged in user has in this channel.
     pub badges: Vec<Badge>,
     /// List of emote set IDs the logged in user has available. This always contains at least 0.
-    pub emote_sets: HashSet<u64>,
+    pub emote_sets: HashSet<String>,
     /// What name color the logged in user has chosen. The same color is used in all channels.
     pub name_color: Option<RGBColor>,
 
@@ -70,7 +70,7 @@ impl From<UserStateMessage> for IRCMessage {
 mod tests {
     use crate::message::commands::userstate::UserStateMessage;
     use crate::message::twitch::RGBColor;
-    use crate::message::IRCMessage;
+    use crate::message::{IRCMessage, Badge};
     use std::convert::TryFrom;
 
     #[test]
@@ -86,11 +86,35 @@ mod tests {
                 user_name: "TESTUSER".to_owned(),
                 badge_info: vec![],
                 badges: vec![],
-                emote_sets: vec![0].into_iter().collect(),
+                emote_sets: vec!["0".to_string()].into_iter().collect(),
                 name_color: Some(RGBColor {
                     r: 0xFF,
                     g: 0x00,
                     b: 0x00
+                }),
+                source: irc_message
+            }
+        )
+    }
+
+    #[test]
+    pub fn test_uuid_emote_set_id() {
+        let src = "@badge-info=;badges=moderator/1;color=#8A2BE2;display-name=TESTUSER;emote-sets=0,75c09c7b-332a-43ec-8be8-1d4571706155;mod=1;subscriber=0;user-type=mod :tmi.twitch.tv USERSTATE #randers";
+        let irc_message = IRCMessage::parse(src).unwrap();
+        let msg = UserStateMessage::try_from(irc_message.clone()).unwrap();
+
+        assert_eq!(
+            msg,
+            UserStateMessage {
+                channel_login: "randers".to_owned(),
+                user_name: "TESTUSER".to_owned(),
+                badge_info: vec![],
+                badges: vec![Badge {name: "moderator".to_string(), version: "1".to_string() }],
+                emote_sets: vec!["0".to_string(), "75c09c7b-332a-43ec-8be8-1d4571706155".to_string()].into_iter().collect(),
+                name_color: Some(RGBColor {
+                    r: 0x8A,
+                    g: 0x2B,
+                    b: 0xE2
                 }),
                 source: irc_message
             }

--- a/src/message/commands/userstate.rs
+++ b/src/message/commands/userstate.rs
@@ -70,7 +70,7 @@ impl From<UserStateMessage> for IRCMessage {
 mod tests {
     use crate::message::commands::userstate::UserStateMessage;
     use crate::message::twitch::RGBColor;
-    use crate::message::{IRCMessage, Badge};
+    use crate::message::{Badge, IRCMessage};
     use std::convert::TryFrom;
 
     #[test]
@@ -109,8 +109,16 @@ mod tests {
                 channel_login: "randers".to_owned(),
                 user_name: "TESTUSER".to_owned(),
                 badge_info: vec![],
-                badges: vec![Badge {name: "moderator".to_owned(), version: "1".to_owned() }],
-                emote_sets: vec!["0".to_owned(), "75c09c7b-332a-43ec-8be8-1d4571706155".to_owned()].into_iter().collect(),
+                badges: vec![Badge {
+                    name: "moderator".to_owned(),
+                    version: "1".to_owned()
+                }],
+                emote_sets: vec![
+                    "0".to_owned(),
+                    "75c09c7b-332a-43ec-8be8-1d4571706155".to_owned()
+                ]
+                .into_iter()
+                .collect(),
                 name_color: Some(RGBColor {
                     r: 0x8A,
                     g: 0x2B,

--- a/src/message/commands/userstate.rs
+++ b/src/message/commands/userstate.rs
@@ -86,7 +86,7 @@ mod tests {
                 user_name: "TESTUSER".to_owned(),
                 badge_info: vec![],
                 badges: vec![],
-                emote_sets: vec!["0".to_string()].into_iter().collect(),
+                emote_sets: vec!["0".to_owned()].into_iter().collect(),
                 name_color: Some(RGBColor {
                     r: 0xFF,
                     g: 0x00,
@@ -109,8 +109,8 @@ mod tests {
                 channel_login: "randers".to_owned(),
                 user_name: "TESTUSER".to_owned(),
                 badge_info: vec![],
-                badges: vec![Badge {name: "moderator".to_string(), version: "1".to_string() }],
-                emote_sets: vec!["0".to_string(), "75c09c7b-332a-43ec-8be8-1d4571706155".to_string()].into_iter().collect(),
+                badges: vec![Badge {name: "moderator".to_owned(), version: "1".to_owned() }],
+                emote_sets: vec!["0".to_owned(), "75c09c7b-332a-43ec-8be8-1d4571706155".to_owned()].into_iter().collect(),
                 name_color: Some(RGBColor {
                     r: 0x8A,
                     g: 0x2B,


### PR DESCRIPTION
Emote set ids are strings - the docs say so (see https://dev.twitch.tv/docs/api/reference#get-emote-sets) and also empirically I see uuid-looking strings constantly. I get a bunch of error messages like

```
Error: Failed to parse incoming message as ServerMessage (emitting as generic instead): Could not parse IRC message @badge-info =;badges=moderator/1;color=#8A2BE2;display-name=Bot_Lisk;emote-sets=0,75c09c7b-332a-43ec-8be8-1d4571706155;mod=1;subscriber=0;user-type=mod :tmi.twitch.tv USERSTATE #foxlisk as ServerMessage: Malformed tag value for tag `emote-sets`, value was `0,75c09c7b-332a-43ec-8be8-1d4571706155`
```

That is in fact a valid emote set id; it turns out that it is the set of follower emotes, so I'm guessing that follower emotes were the first ones to break the convention of using integers for emote sets.

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable