### PR TITLE
Fix typo in RoomStateMessage's follower mode (follwers_only -> followers_only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
   See also: #186 and #196
 - Breaking: Removed `ban()`, `unban()`, `timeout()` and `untimeout()` since they are no longer supported by Twitch.
   They were previously deprecated in v4.1.0 (#197)
+- Breaking: Fixed typo in RoomStateMessage's follower mode (was `follwers_only`, is now `followers_only`. (#200)
 - Minor: Added support for reply-parent tags (#189)
 
 ## v5.0.1

--- a/src/message/commands/roomstate.rs
+++ b/src/message/commands/roomstate.rs
@@ -34,7 +34,7 @@ pub struct RoomStateMessage {
     /// (Controlled by `/followers` and `/followersoff` commands in chat)
     ///
     /// See the documentation on `FollowersOnlyMode` for more details on the possible settings.
-    pub follwers_only: Option<FollowersOnlyMode>,
+    pub followers_only: Option<FollowersOnlyMode>,
 
     /// If present, specifies a new setting for the "r9k" beta mode (also sometimes called
     /// unique-chat mode, controlled by the `/r9kbeta` and `/r9kbetaoff` commands)
@@ -106,7 +106,7 @@ impl TryFrom<IRCMessage> for RoomStateMessage {
             channel_login: source.try_get_channel_login()?.to_owned(),
             channel_id: source.try_get_nonempty_tag_value("room-id")?.to_owned(),
             emote_only: source.try_get_optional_bool("emote-only")?,
-            follwers_only: source
+            followers_only: source
                 .try_get_optional_number::<i64>("followers-only")?
                 .map(|n| match n {
                     n if n >= 0 => FollowersOnlyMode::Enabled(Duration::from_secs((n * 60) as u64)),
@@ -147,7 +147,7 @@ mod tests {
                 channel_login: "randers".to_owned(),
                 channel_id: "40286300".to_owned(),
                 emote_only: Some(false),
-                follwers_only: Some(FollowersOnlyMode::Disabled),
+                followers_only: Some(FollowersOnlyMode::Disabled),
                 r9k: Some(false),
                 slow_mode: Some(Duration::from_secs(0)),
                 subscribers_only: Some(false),
@@ -168,7 +168,7 @@ mod tests {
                 channel_login: "randers".to_owned(),
                 channel_id: "40286300".to_owned(),
                 emote_only: Some(true),
-                follwers_only: Some(FollowersOnlyMode::Enabled(Duration::from_secs(0))),
+                followers_only: Some(FollowersOnlyMode::Enabled(Duration::from_secs(0))),
                 r9k: Some(true),
                 slow_mode: Some(Duration::from_secs(5)),
                 subscribers_only: Some(true),
@@ -184,7 +184,7 @@ mod tests {
         let msg = RoomStateMessage::try_from(irc_message).unwrap();
 
         assert_eq!(
-            msg.follwers_only,
+            msg.followers_only,
             Some(FollowersOnlyMode::Enabled(Duration::from_secs(10 * 60))) // 10 minutes
         )
     }
@@ -201,7 +201,7 @@ mod tests {
                 channel_login: "randers".to_owned(),
                 channel_id: "40286300".to_owned(),
                 emote_only: None,
-                follwers_only: None,
+                followers_only: None,
                 r9k: None,
                 slow_mode: Some(Duration::from_secs(5)),
                 subscribers_only: None,
@@ -222,7 +222,7 @@ mod tests {
                 channel_login: "randers".to_owned(),
                 channel_id: "40286300".to_owned(),
                 emote_only: Some(true),
-                follwers_only: None,
+                followers_only: None,
                 r9k: None,
                 slow_mode: None,
                 subscribers_only: None,


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
