### PR TITLE
Replace Strings with FastStr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
+- All `String`s replaced with FastStr, thanks to `fast_str` crate author, @xxXyh1908.
+
 - Breaking: Fixed a erroneous implementation of the IRCv3 tags: This crate now no longer differentiates
   between empty and missing IRCv3 tag values (e.g. `@key` is equivalent to `@key=`). The type of the
   `IRCTags` struct has changed to hold a `HashMap<String, String>` instead of a `HashMap<String, Option<String>>`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ bytes = { version = "1", optional = true }
 chrono = { version = "0.4", default-features = false }
 either = "1"
 enum_dispatch = "0.3"
+fast-str = { version = "1.0.0", features = ["stack", "serde"] }
 futures-util = { version = "0.3", default-features = false, features = ["async-await", "sink", "std"] }
 prometheus = { version = "0.13", default-features = false, optional = true }
 reqwest = { version = "0.11", default-features = false, features = ["json"], optional = true }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -15,6 +15,7 @@ use crate::metrics::MetricsBundle;
 use crate::transport::Transport;
 use crate::validate::validate_login;
 use crate::{irc, validate};
+use fast_str::FastStr;
 use std::collections::HashSet;
 use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot};
@@ -121,7 +122,11 @@ impl<T: Transport, L: LoginCredentials> TwitchIRCClient<T, L> {
     ///
     /// If you want to just send a normal chat message, `say()` should be preferred since it
     /// prevents commands like `/ban` from accidentally being executed.
-    pub async fn privmsg(&self, channel_login: String, message: String) -> Result<(), Error<T, L>> {
+    pub async fn privmsg(
+        &self,
+        channel_login: FastStr,
+        message: FastStr,
+    ) -> Result<(), Error<T, L>> {
         self.send_message(irc!["PRIVMSG", format!("#{}", channel_login), message])
             .await
     }
@@ -135,8 +140,12 @@ impl<T: Transport, L: LoginCredentials> TwitchIRCClient<T, L> {
     /// No particular filtering is performed on the message. If the message is too long for chat,
     /// it will not be cut short or split into multiple messages (what happens is determined
     /// by the behaviour of the Twitch IRC server).
-    pub async fn say(&self, channel_login: String, message: String) -> Result<(), Error<T, L>> {
-        self.privmsg(channel_login, format!(". {}", message)).await
+    pub async fn say(&self, channel_login: FastStr, message: FastStr) -> Result<(), Error<T, L>> {
+        self.privmsg(
+            channel_login,
+            FastStr::from_string(format!(". {}", message)),
+        )
+        .await
     }
 
     /// Say a `/me` chat message in the given Twitch channel. These messages are usually
@@ -160,9 +169,12 @@ impl<T: Transport, L: LoginCredentials> TwitchIRCClient<T, L> {
     /// No particular filtering is performed on the message. If the message is too long for chat,
     /// it will not be cut short or split into multiple messages (what happens is determined
     /// by the behaviour of the Twitch IRC server).
-    pub async fn me(&self, channel_login: String, message: String) -> Result<(), Error<T, L>> {
-        self.privmsg(channel_login, format!("/me {}", message))
-            .await
+    pub async fn me(&self, channel_login: FastStr, message: FastStr) -> Result<(), Error<T, L>> {
+        self.privmsg(
+            channel_login,
+            FastStr::from_string(format!("/me {}", message)),
+        )
+        .await
     }
 
     /// Reply to a given message. The sent message is tagged to be in reply of the
@@ -181,7 +193,7 @@ impl<T: Transport, L: LoginCredentials> TwitchIRCClient<T, L> {
     /// be one of the following:
     ///
     /// * a [`&PrivmsgMessage`](crate::message::PrivmsgMessage)
-    /// * a tuple `(&str, &str)` or `(String, String)`, where the first member is the login name
+    /// * a tuple `(&str, &str)` or `(FastStr, FastStr)`, where the first member is the login name
     ///   of the channel the message was sent to, and the second member is the ID of the message
     ///   to reply to.
     ///
@@ -192,7 +204,7 @@ impl<T: Transport, L: LoginCredentials> TwitchIRCClient<T, L> {
     pub async fn say_in_reply_to(
         &self,
         reply_to: &impl ReplyToMessage,
-        message: String,
+        message: FastStr,
     ) -> Result<(), Error<T, L>> {
         self.say_or_me_in_reply_to(reply_to, message, false).await
     }
@@ -216,7 +228,7 @@ impl<T: Transport, L: LoginCredentials> TwitchIRCClient<T, L> {
     /// be one of the following:
     ///
     /// * a [`&PrivmsgMessage`](crate::message::PrivmsgMessage)
-    /// * a tuple `(&str, &str)` or `(String, String)`, where the first member is the login name
+    /// * a tuple `(&str, &str)` or `(FastStr, FastStr)`, where the first member is the login name
     ///   of the channel the message was sent to, and the second member is the ID of the message
     ///   to reply to.
     ///
@@ -227,7 +239,7 @@ impl<T: Transport, L: LoginCredentials> TwitchIRCClient<T, L> {
     pub async fn me_in_reply_to(
         &self,
         reply_to: &impl ReplyToMessage,
-        message: String,
+        message: FastStr,
     ) -> Result<(), Error<T, L>> {
         self.say_or_me_in_reply_to(reply_to, message, true).await
     }
@@ -235,7 +247,7 @@ impl<T: Transport, L: LoginCredentials> TwitchIRCClient<T, L> {
     async fn say_or_me_in_reply_to(
         &self,
         reply_to: &impl ReplyToMessage,
-        message: String,
+        message: FastStr,
         me: bool,
     ) -> Result<(), Error<T, L>> {
         let mut tags = IRCTags::new();
@@ -247,10 +259,10 @@ impl<T: Transport, L: LoginCredentials> TwitchIRCClient<T, L> {
         let irc_message = IRCMessage::new(
             tags,
             None,
-            "PRIVMSG".to_owned(),
+            FastStr::from_static("PRIVMSG"),
             vec![
-                format!("#{}", reply_to.channel_login()),
-                format!("{} {}", if me { "/me" } else { "." }, message),
+                FastStr::from_string(format!("#{}", reply_to.channel_login())),
+                FastStr::from_string(format!("{} {}", if me { "/me" } else { "." }, message)),
             ], // The prefixed "." prevents commands from being executed if not in /me-mode
         );
         self.send_message(irc_message).await
@@ -291,7 +303,7 @@ impl<T: Transport, L: LoginCredentials> TwitchIRCClient<T, L> {
     ///
     /// Returns a [validate::Error] if the passed `channel_login` is of
     /// [invalid format](crate::validate::validate_login). Returns `Ok(())` otherwise.
-    pub fn join(&self, channel_login: String) -> Result<(), validate::Error> {
+    pub fn join(&self, channel_login: FastStr) -> Result<(), validate::Error> {
         validate_login(&channel_login)?;
 
         self.client_loop_tx
@@ -309,7 +321,7 @@ impl<T: Transport, L: LoginCredentials> TwitchIRCClient<T, L> {
     ///
     /// Returns a [validate::Error] if the passed `channel_login` is of
     /// [invalid format](crate::validate::validate_login). Returns `Ok(())` otherwise.
-    pub fn set_wanted_channels(&self, channels: HashSet<String>) -> Result<(), validate::Error> {
+    pub fn set_wanted_channels(&self, channels: HashSet<FastStr>) -> Result<(), validate::Error> {
         for channel_login in channels.iter() {
             validate_login(channel_login)?;
         }
@@ -344,8 +356,8 @@ impl<T: Transport, L: LoginCredentials> TwitchIRCClient<T, L> {
     ///
     /// `(false, false)` is returned for a channel that has not been joined previously at all
     /// or where a previous `PART` command has completed.
-    pub async fn get_channel_status(&self, channel_login: String) -> (bool, bool) {
-        // channel_login format sanity check not really needed here, the code will deal with arbitrary strings just fine
+    pub async fn get_channel_status(&self, channel_login: FastStr) -> (bool, bool) {
+        // channel_login format sanity check not really needed here, the code will deal with arbitrary FastStrs just fine
 
         let (return_tx, return_rx) = oneshot::channel();
         self.client_loop_tx
@@ -362,8 +374,8 @@ impl<T: Transport, L: LoginCredentials> TwitchIRCClient<T, L> {
     ///
     /// This has the same semantics as `join()`. Similarly, a `part()` call will have no effect
     /// if the channel is not currently joined.
-    pub fn part(&self, channel_login: String) {
-        // channel_login format sanity check not really needed here, the code will deal with arbitrary strings just fine
+    pub fn part(&self, channel_login: FastStr) {
+        // channel_login format sanity check not really needed here, the code will deal with arbitrary FastStrs just fine
 
         self.client_loop_tx
             .send(ClientLoopCommand::Part { channel_login })

--- a/src/client/pool_connection.rs
+++ b/src/client/pool_connection.rs
@@ -2,6 +2,7 @@ use crate::config::ClientConfig;
 use crate::connection::Connection;
 use crate::login::LoginCredentials;
 use crate::transport::Transport;
+use fast_str::FastStr;
 use std::collections::{HashSet, VecDeque};
 use std::sync::Arc;
 use std::time::Instant;
@@ -30,9 +31,9 @@ pub(crate) struct PoolConnection<T: Transport, L: LoginCredentials> {
     /// The connection handle that this is wrapping
     pub connection: Arc<Connection<T, L>>,
     /// see the documentation on `TwitchIRCClient` for what `wanted_channels` and `server_channels` mean
-    pub wanted_channels: HashSet<String>,
+    pub wanted_channels: HashSet<FastStr>,
     /// see the documentation on `TwitchIRCClient` for what `wanted_channels` and `server_channels` mean
-    pub server_channels: HashSet<String>,
+    pub server_channels: HashSet<FastStr>,
     /// this has a list of times when messages were sent out on this pool connection,
     /// at the front there will be the oldest, and at the back the newest entries
     pub message_send_times: VecDeque<Instant>,

--- a/src/message/commands/clearchat.rs
+++ b/src/message/commands/clearchat.rs
@@ -1,7 +1,7 @@
 use crate::message::commands::IRCMessageParseExt;
 use crate::message::{IRCMessage, ServerMessageParseError};
 use chrono::{DateTime, Utc};
-use std::convert::TryFrom;
+use fast_str::FastStr;
 use std::str::FromStr;
 use std::time::Duration;
 
@@ -12,12 +12,18 @@ use {serde::Deserialize, serde::Serialize};
 ///
 /// This represents the `CLEARCHAT` IRC command.
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "with-serde", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    feature = "with-serde",
+    derive(
+        Serialize,
+        Deserialize
+    )
+)]
 pub struct ClearChatMessage {
     /// Login name of the channel that this message was sent to
-    pub channel_login: String,
+    pub channel_login: FastStr,
     /// ID of the channel that this message was sent to
-    pub channel_id: String,
+    pub channel_id: FastStr,
     /// The action that this `CLEARCHAT` message encodes - one of Timeout, Permaban, and the
     /// chat being cleared. See `ClearChatAction` for details
     pub action: ClearChatAction,
@@ -30,23 +36,29 @@ pub struct ClearChatMessage {
 
 /// One of the three types of meaning a `CLEARCHAT` message can have.
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "with-serde", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    feature = "with-serde",
+    derive(
+        Serialize,
+        Deserialize
+    )
+)]
 pub enum ClearChatAction {
     /// A moderator cleared the entire chat.
     ChatCleared,
     /// A user was permanently banned.
     UserBanned {
         /// Login name of the user that was banned
-        user_login: String,
+        user_login: FastStr,
         /// ID of the user that was banned
-        user_id: String,
+        user_id: FastStr,
     },
     /// A user was temporarily banned (timed out).
     UserTimedOut {
         /// Login name of the user that was banned
-        user_login: String,
+        user_login: FastStr,
         /// ID of the user that was banned
-        user_id: String,
+        user_id: FastStr,
         /// Duration that the user was timed out for.
         timeout_length: Duration,
     },
@@ -70,28 +82,30 @@ impl TryFrom<IRCMessage> for ClearChatMessage {
         let action = match source.params.get(1) {
             Some(user_login) => {
                 // ban or timeout
-                let user_id = source.try_get_nonempty_tag_value("target-user-id")?;
+                let user_id =
+                    FastStr::from_ref(source.try_get_nonempty_tag_value("target-user-id")?);
 
                 let ban_duration = source.try_get_optional_nonempty_tag_value("ban-duration")?;
                 match ban_duration {
                     Some(ban_duration) => {
                         let ban_duration = u64::from_str(ban_duration).map_err(|_| {
+                            let ban_duration = FastStr::from_ref(ban_duration);
                             ServerMessageParseError::MalformedTagValue(
-                                source.to_owned(),
+                                source.clone(),
                                 "ban-duration",
-                                ban_duration.to_owned(),
+                                ban_duration,
                             )
                         })?;
 
                         ClearChatAction::UserTimedOut {
-                            user_login: user_login.to_owned(),
-                            user_id: user_id.to_owned(),
+                            user_login: user_login.clone(), // Clone allowed because it's params. FastStr may turn it into Arc.
+                            user_id: user_id,
                             timeout_length: Duration::from_secs(ban_duration),
                         }
                     }
                     None => ClearChatAction::UserBanned {
-                        user_login: user_login.to_owned(),
-                        user_id: user_id.to_owned(),
+                        user_login: user_login.clone(),
+                        user_id: user_id.clone(),
                     },
                 }
             }
@@ -99,8 +113,8 @@ impl TryFrom<IRCMessage> for ClearChatMessage {
         };
 
         Ok(ClearChatMessage {
-            channel_login: source.try_get_channel_login()?.to_owned(),
-            channel_id: source.try_get_nonempty_tag_value("room-id")?.to_owned(),
+            channel_login: FastStr::from_ref(source.try_get_channel_login()?),
+            channel_id: FastStr::from_ref(source.try_get_nonempty_tag_value("room-id")?),
             action,
             server_timestamp: source.try_get_timestamp("tmi-sent-ts")?,
             source,

--- a/src/message/commands/clearmsg.rs
+++ b/src/message/commands/clearmsg.rs
@@ -1,6 +1,7 @@
 use crate::message::commands::IRCMessageParseExt;
 use crate::message::{IRCMessage, ServerMessageParseError};
 use chrono::{DateTime, Utc};
+use fast_str::FastStr;
 use std::convert::TryFrom;
 
 #[cfg(feature = "with-serde")]
@@ -10,18 +11,24 @@ use {serde::Deserialize, serde::Serialize};
 ///
 /// The deleted message is identified by its `message_id`.
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "with-serde", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    feature = "with-serde",
+    derive(
+        Serialize,
+        Deserialize
+    )
+)]
 pub struct ClearMsgMessage {
     /// Login name of the channel that the deleted message was posted in.
-    pub channel_login: String,
-    // pub channel_id: String,
+    pub channel_login: FastStr,
+    // pub channel_id: FastStr,
     /// login name of the user that sent the original message that was deleted by this
     /// `CLEARMSG`.
-    pub sender_login: String,
+    pub sender_login: FastStr,
     /// ID of the message that was deleted.
-    pub message_id: String,
+    pub message_id: FastStr,
     /// Text of the message that was deleted
-    pub message_text: String,
+    pub message_text: FastStr,
     /// Whether the deleted message was an action (`/me`)
     pub is_action: bool,
     /// server timestamp for the time when the delete command was executed.
@@ -46,14 +53,12 @@ impl TryFrom<IRCMessage> for ClearMsgMessage {
         let (message_text, is_action) = source.try_get_message_text()?;
 
         Ok(ClearMsgMessage {
-            channel_login: source.try_get_channel_login()?.to_owned(),
+            channel_login: FastStr::from_ref(source.try_get_channel_login()?),
             // channel_id: source.try_get_nonempty_tag_value("room-id")?.to_owned(),
-            sender_login: source.try_get_nonempty_tag_value("login")?.to_owned(),
-            message_id: source
-                .try_get_nonempty_tag_value("target-msg-id")?
-                .to_owned(),
+            sender_login: FastStr::from_ref(source.try_get_nonempty_tag_value("login")?),
+            message_id: FastStr::from_ref(source.try_get_nonempty_tag_value("target-msg-id")?),
             server_timestamp: source.try_get_timestamp("tmi-sent-ts")?,
-            message_text: message_text.to_owned(),
+            message_text: FastStr::from_ref(message_text),
             is_action,
             source,
         })

--- a/src/message/commands/globaluserstate.rs
+++ b/src/message/commands/globaluserstate.rs
@@ -1,8 +1,9 @@
+use fast_str::FastStr;
+
 use crate::message::commands::IRCMessageParseExt;
 use crate::message::twitch::{Badge, RGBColor};
 use crate::message::{IRCMessage, ServerMessageParseError};
 use std::collections::HashSet;
-use std::convert::TryFrom;
 
 #[cfg(feature = "with-serde")]
 use {serde::Deserialize, serde::Serialize};
@@ -11,12 +12,18 @@ use {serde::Deserialize, serde::Serialize};
 ///
 /// This message is not sent if you log into chat as an anonymous user.
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "with-serde", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    feature = "with-serde",
+    derive(
+        Serialize,
+        Deserialize
+    )
+)]
 pub struct GlobalUserStateMessage {
     /// ID of the logged in user
-    pub user_id: String,
+    pub user_id: FastStr,
     /// Name (also called display name) of the logged in user
-    pub user_name: String,
+    pub user_name: FastStr,
     /// Metadata related to the chat badges in the `badges` tag.
     ///
     /// Currently this is used only for `subscriber`, to indicate the exact number of months
@@ -30,7 +37,7 @@ pub struct GlobalUserStateMessage {
     /// List of badges the logged in user has in all channels.
     pub badges: Vec<Badge>,
     /// List of emote set IDs the logged in user has available. This always contains at least one entry ("0").
-    pub emote_sets: HashSet<String>,
+    pub emote_sets: HashSet<FastStr>,
     /// What name color the logged in user has chosen. The same color is used in all channels.
     pub name_color: Option<RGBColor>,
 
@@ -50,10 +57,8 @@ impl TryFrom<IRCMessage> for GlobalUserStateMessage {
         // @badge-info=;badges=;color=#19E6E6;display-name=randers;emote-sets=0,42,237,4236,15961,19194,771823,1511293,1641460,1641461,1641462,300206295,300374282,300432482,300548756,472873131,477339272,488737509,537206155,625908879;user-id=40286300;user-type= :tmi.twitch.tv GLOBALUSERSTATE
 
         Ok(GlobalUserStateMessage {
-            user_id: source.try_get_nonempty_tag_value("user-id")?.to_owned(),
-            user_name: source
-                .try_get_nonempty_tag_value("display-name")?
-                .to_owned(),
+            user_id: FastStr::from_ref(source.try_get_nonempty_tag_value("user-id")?),
+            user_name: FastStr::from_ref(source.try_get_nonempty_tag_value("display-name")?),
             badge_info: source.try_get_badges("badge-info")?,
             badges: source.try_get_badges("badges")?,
             emote_sets: source.try_get_emote_sets("emote-sets")?,

--- a/src/message/commands/join.rs
+++ b/src/message/commands/join.rs
@@ -1,3 +1,5 @@
+use fast_str::FastStr;
+
 use crate::message::commands::{IRCMessageParseExt, ServerMessageParseError};
 use crate::message::IRCMessage;
 use std::convert::TryFrom;
@@ -7,13 +9,19 @@ use {serde::Deserialize, serde::Serialize};
 
 /// Message received when you successfully join a channel.
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "with-serde", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    feature = "with-serde",
+    derive(
+        Serialize,
+        Deserialize
+    )
+)]
 pub struct JoinMessage {
     /// Login name of the channel you joined.
-    pub channel_login: String,
+    pub channel_login: FastStr,
     /// The login name of the logged in user (the login name of the user that joined the channel,
     /// which is the logged in user).
-    pub user_login: String,
+    pub user_login: FastStr,
 
     /// The message that this `JoinMessage` was parsed from.
     pub source: IRCMessage,
@@ -28,8 +36,8 @@ impl TryFrom<IRCMessage> for JoinMessage {
         }
 
         Ok(JoinMessage {
-            channel_login: source.try_get_channel_login()?.to_owned(),
-            user_login: source.try_get_prefix_nickname()?.to_owned(),
+            channel_login: FastStr::from_ref(source.try_get_channel_login()?),
+            user_login: FastStr::from_ref(source.try_get_prefix_nickname()?),
             source,
         })
     }

--- a/src/message/commands/mod.rs
+++ b/src/message/commands/mod.rs
@@ -28,6 +28,7 @@ use crate::message::{
     ReplyParent, RoomStateMessage, TwitchUserBasics, UserNoticeMessage, WhisperMessage,
 };
 use chrono::{DateTime, TimeZone, Utc};
+use fast_str::FastStr;
 use std::collections::HashSet;
 use std::convert::TryFrom;
 use std::ops::Range;
@@ -56,7 +57,7 @@ pub enum ServerMessageParseError {
     MissingTagValue(IRCMessage, &'static str),
     /// Malformed tag value for tag `key`, value was `value`
     #[error("Could not parse IRC message {} as ServerMessage: Malformed tag value for tag `{1}`, value was `{2}`", .0.as_raw_irc())]
-    MalformedTagValue(IRCMessage, &'static str, String),
+    MalformedTagValue(IRCMessage, &'static str, FastStr),
     /// No parameter found at index `n`
     #[error("Could not parse IRC message {} as ServerMessage: No parameter found at index {1}", .0.as_raw_irc())]
     MissingParameter(IRCMessage, usize),
@@ -113,7 +114,7 @@ trait IRCMessageParseExt {
     fn try_get_emote_sets(
         &self,
         tag_key: &'static str,
-    ) -> Result<HashSet<String>, ServerMessageParseError>;
+    ) -> Result<HashSet<FastStr>, ServerMessageParseError>;
     fn try_get_badges(&self, tag_key: &'static str) -> Result<Vec<Badge>, ServerMessageParseError>;
     fn try_get_color(
         &self,
@@ -244,7 +245,8 @@ impl IRCMessageParseExt for IRCMessage {
 
         let mut emotes = Vec::new();
 
-        let make_error = || MalformedTagValue(self.to_owned(), tag_key, tag_value.to_owned());
+        let make_error =
+            || MalformedTagValue(self.to_owned(), tag_key, FastStr::from_ref(tag_value));
 
         // emotes tag format:
         // emote_id:from-to,from-to,from-to/emote_id:from-to,from-to/emote_id:from-to
@@ -266,14 +268,14 @@ impl IRCMessageParseExt for IRCMessage {
                     .chars()
                     .skip(start)
                     .take(code_length)
-                    .collect::<String>();
+                    .collect::<FastStr>();
 
                 // we intentionally gracefully handle indices that are out of bounds for the
-                // given string by taking as much as possible until the end of the string.
+                // given FastStr by taking as much as possible until the end of the FastStr.
                 // This is to work around a Twitch bug: https://github.com/twitchdev/issues/issues/104
 
                 emotes.push(Emote {
-                    id: emote_id.to_owned(),
+                    id: FastStr::from_ref(emote_id),
                     char_range: Range { start, end },
                     code,
                 });
@@ -288,13 +290,13 @@ impl IRCMessageParseExt for IRCMessage {
     fn try_get_emote_sets(
         &self,
         tag_key: &'static str,
-    ) -> Result<HashSet<String>, ServerMessageParseError> {
+    ) -> Result<HashSet<FastStr>, ServerMessageParseError> {
         let src = self.try_get_tag_value(tag_key)?;
 
         if src.is_empty() {
             Ok(HashSet::new())
         } else {
-            Ok(src.split(',').map(|s| s.to_owned()).collect())
+            Ok(src.split(',').map(|s| FastStr::from_ref(s)).collect())
         }
     }
 
@@ -308,7 +310,8 @@ impl IRCMessageParseExt for IRCMessage {
 
         let mut badges = Vec::new();
 
-        let make_error = || MalformedTagValue(self.to_owned(), tag_key, tag_value.to_owned());
+        let make_error =
+            || MalformedTagValue(self.to_owned(), tag_key, FastStr::from_ref(tag_value));
 
         // badges tag format:
         // admin/1,moderator/1,subscriber/12
@@ -316,8 +319,8 @@ impl IRCMessageParseExt for IRCMessage {
             let (name, version) = src.split_once('/').ok_or_else(make_error)?;
 
             badges.push(Badge {
-                name: name.to_owned(),
-                version: version.to_owned(),
+                name: FastStr::from_ref(name),
+                version: FastStr::from_ref(version),
             });
         }
 
@@ -329,7 +332,8 @@ impl IRCMessageParseExt for IRCMessage {
         tag_key: &'static str,
     ) -> Result<Option<RGBColor>, ServerMessageParseError> {
         let tag_value = self.try_get_tag_value(tag_key)?;
-        let make_error = || MalformedTagValue(self.to_owned(), tag_key, tag_value.to_owned());
+        let make_error =
+            || MalformedTagValue(self.to_owned(), tag_key, FastStr::from_ref(tag_value));
 
         if tag_value.is_empty() {
             return Ok(None);
@@ -352,8 +356,9 @@ impl IRCMessageParseExt for IRCMessage {
         tag_key: &'static str,
     ) -> Result<N, ServerMessageParseError> {
         let tag_value = self.try_get_nonempty_tag_value(tag_key)?;
-        let number = N::from_str(tag_value)
-            .map_err(|_| MalformedTagValue(self.to_owned(), tag_key, tag_value.to_owned()))?;
+        let number = N::from_str(tag_value).map_err(|_| {
+            MalformedTagValue(self.to_owned(), tag_key, FastStr::from_ref(tag_value))
+        })?;
         Ok(number)
     }
 
@@ -373,8 +378,9 @@ impl IRCMessageParseExt for IRCMessage {
             None => return Ok(None),
         };
 
-        let number = N::from_str(tag_value)
-            .map_err(|_| MalformedTagValue(self.to_owned(), tag_key, tag_value.to_owned()))?;
+        let number = N::from_str(tag_value).map_err(|_| {
+            MalformedTagValue(self.to_owned(), tag_key, FastStr::from_ref(tag_value))
+        })?;
         Ok(Some(number))
     }
 
@@ -391,11 +397,14 @@ impl IRCMessageParseExt for IRCMessage {
     ) -> Result<DateTime<Utc>, ServerMessageParseError> {
         // e.g. tmi-sent-ts.
         let tag_value = self.try_get_nonempty_tag_value(tag_key)?;
-        let milliseconds_since_epoch = i64::from_str(tag_value)
-            .map_err(|_| MalformedTagValue(self.to_owned(), tag_key, tag_value.to_owned()))?;
+        let milliseconds_since_epoch = i64::from_str(tag_value).map_err(|_| {
+            MalformedTagValue(self.to_owned(), tag_key, FastStr::from_ref(tag_value))
+        })?;
         Utc.timestamp_millis_opt(milliseconds_since_epoch)
             .single()
-            .ok_or_else(|| MalformedTagValue(self.to_owned(), tag_key, tag_value.to_owned()))
+            .ok_or_else(|| {
+                MalformedTagValue(self.to_owned(), tag_key, FastStr::from_ref(tag_value))
+            })
     }
 
     fn try_get_optional_reply_parent(
@@ -407,19 +416,17 @@ impl IRCMessageParseExt for IRCMessage {
         }
 
         Ok(Some(ReplyParent {
-            message_id: self.try_get_tag_value("reply-parent-msg-id")?.to_owned(),
+            message_id: FastStr::from_ref(self.try_get_tag_value("reply-parent-msg-id")?),
             reply_parent_user: TwitchUserBasics {
-                id: self
-                    .try_get_nonempty_tag_value("reply-parent-user-id")?
-                    .to_owned(),
-                login: self
-                    .try_get_nonempty_tag_value("reply-parent-user-login")?
-                    .to_owned(),
-                name: self
-                    .try_get_nonempty_tag_value("reply-parent-display-name")?
-                    .to_owned(),
+                id: FastStr::from_ref(self.try_get_nonempty_tag_value("reply-parent-user-id")?),
+                login: FastStr::from_ref(
+                    self.try_get_nonempty_tag_value("reply-parent-user-login")?,
+                ),
+                name: FastStr::from_ref(
+                    self.try_get_nonempty_tag_value("reply-parent-display-name")?,
+                ),
             },
-            message_text: self.try_get_tag_value("reply-parent-msg-body")?.to_owned(),
+            message_text: FastStr::from_ref(self.try_get_tag_value("reply-parent-msg-body")?),
         }))
     }
 }
@@ -431,7 +438,13 @@ impl IRCMessageParseExt for IRCMessage {
 // which combined with #[non_exhaustive] allows us to add enum variants
 // without making a major release
 #[derive(Debug, PartialEq, Eq, Clone)]
-#[cfg_attr(feature = "with-serde", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    feature = "with-serde",
+    derive(
+        Serialize,
+        Deserialize
+    )
+)]
 #[doc(hidden)]
 pub struct HiddenIRCMessage(pub(self) IRCMessage);
 
@@ -469,7 +482,13 @@ pub struct HiddenIRCMessage(pub(self) IRCMessage);
 /// }
 /// ```
 #[derive(Debug, Clone)]
-#[cfg_attr(feature = "with-serde", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    feature = "with-serde",
+    derive(
+        Serialize,
+        Deserialize
+    )
+)]
 #[non_exhaustive]
 pub enum ServerMessage {
     /// `CLEARCHAT` message

--- a/src/message/twitch.rs
+++ b/src/message/twitch.rs
@@ -3,15 +3,23 @@
 use std::fmt::{Display, Formatter};
 use std::ops::Range;
 
+use fast_str::FastStr;
+
 #[cfg(feature = "with-serde")]
 use {serde::Deserialize, serde::Serialize};
 
 /// Set of information describing the basic details of a Twitch user.
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "with-serde", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    feature = "with-serde",
+    derive(
+        Serialize,
+        Deserialize
+    )
+)]
 pub struct TwitchUserBasics {
     /// The user's unique ID, e.g. `103973901`
-    pub id: String,
+    pub id: FastStr,
     /// The user's login name. For many users, this is simply the lowercased version of their
     /// (display) name, but there are also many users where there is no direct relation between
     /// `login` and `name`.
@@ -23,7 +31,7 @@ pub struct TwitchUserBasics {
     /// The `login` name is used in many places to refer to users, e.g. in the URL for their channel page,
     /// or also in almost all places on the Twitch IRC interface (e.g. when sending a message to a
     /// channel, you specify the channel by its login name instead of ID).
-    pub login: String,
+    pub login: FastStr,
     /// Display name of the user. When possible a user should be referred to using this name
     /// in user-facing contexts.
     ///
@@ -31,7 +39,7 @@ pub struct TwitchUserBasics {
     /// should avoid making assumptions about the format of this value.
     /// For example, the `name` can contain non-ascii characters, it can contain spaces and
     /// it can have spaces at the start and end (albeit rare).
-    pub name: String,
+    pub name: FastStr,
 }
 
 /// An RGB color, used to color chat user's names.
@@ -46,10 +54,16 @@ pub struct TwitchUserBasics {
 ///     g: 0x00,
 ///     b: 0x0F
 /// };
-/// assert_eq!(color.to_string(), "#12000F");
+/// assert_eq!(color.to_FastStr(), "#12000F");
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "with-serde", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    feature = "with-serde",
+    derive(
+        Serialize,
+        Deserialize
+    )
+)]
 pub struct RGBColor {
     /// Red component
     pub r: u8,
@@ -67,12 +81,18 @@ impl Display for RGBColor {
 
 /// A single emote, appearing as part of a message.
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "with-serde", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    feature = "with-serde",
+    derive(
+        Serialize,
+        Deserialize
+    )
+)]
 pub struct Emote {
     /// An ID identifying this emote. For example `25` for the "Kappa" emote, but can also be non-numeric,
     /// for example on emotes modified using Twitch channel points, e.g.
     /// `301512758_TK` for `pajaDent_TK` where `301512758` is the ID of the original `pajaDent` emote.
-    pub id: String,
+    pub id: FastStr,
     /// A range of characters in the original message where the emote is placed.
     ///
     /// As is documented on `Range`, the `start` index of this range is inclusive, while the
@@ -81,45 +101,57 @@ pub struct Emote {
     /// This is always the exact range of characters that Twitch originally sent.
     /// Note that due to [a Twitch bug](https://github.com/twitchdev/issues/issues/104)
     /// (that this library intentionally works around), the character range specified here
-    /// might be out-of-bounds for the original message text string.
+    /// might be out-of-bounds for the original message text FastStr.
     pub char_range: Range<usize>,
     /// This is the text that this emote replaces, e.g. `Kappa` or `:)`.
-    pub code: String,
+    pub code: FastStr,
 }
 
 /// A single Twitch "badge" to be shown next to the user's name in chat.
 ///
 /// The combination of `name` and `version` fully describes the exact badge to display.
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "with-serde", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    feature = "with-serde",
+    derive(
+        Serialize,
+        Deserialize
+    )
+)]
 pub struct Badge {
-    /// A string identifying the type of badge. For example, `admin`, `moderator` or `subscriber`.
-    pub name: String,
+    /// A FastStr identifying the type of badge. For example, `admin`, `moderator` or `subscriber`.
+    pub name: FastStr,
     /// A (usually) numeric version of this badge. Most badges only have one version (then usually
     /// version will be `0` or `1`), but other types of badges have different versions (e.g. `subscriber`)
     /// to differentiate between levels, or lengths, or similar, depending on the badge.
-    pub version: String,
+    pub version: FastStr,
 }
 
 /// If a message is sent in reply to another one, Twitch provides some basic information about the message
 /// that was replied to. It is optional, as not every message will be in reply to another message.
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "with-serde", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    feature = "with-serde",
+    derive(
+        Serialize,
+        Deserialize
+    )
+)]
 pub struct ReplyParent {
     /// Message UUID that this message is replying to.
-    pub message_id: String,
+    pub message_id: FastStr,
     /// User that sent the message that is replying to.
     pub reply_parent_user: TwitchUserBasics,
     /// The text of the message that this message is replying to.
-    pub message_text: String,
+    pub message_text: FastStr,
 }
 
 /// Extract the `message_id` from a [`PrivmsgMessage`](crate::message::PrivmsgMessage) or directly
-/// use an arbitrary [`String`] or [`&str`] as a message ID. This trait allows you to plug both
+/// use an arbitrary [`FastStr`] or [`&str`] as a message ID. This trait allows you to plug both
 /// of these types directly into [`say_in_reply_to()`](crate::TwitchIRCClient::say_in_reply_to)
 /// for your convenience.
 ///
-/// For tuples `(&str, &str)` or `(String, String)`, the first member is the login name
+/// For tuples `(&str, &str)` or `(FastStr, FastStr)`, the first member is the login name
 /// of the channel the message was sent to, and the second member is the ID of the message
 /// to be deleted.
 ///
@@ -130,7 +162,7 @@ pub struct ReplyParent {
 pub trait ReplyToMessage {
     /// Login name of the channel that the message was sent to.
     fn channel_login(&self) -> &str;
-    /// The unique string identifying the message, specified on the message via the `id` tag.
+    /// The unique FastStr identifying the message, specified on the message via the `id` tag.
     fn message_id(&self) -> &str;
 }
 
@@ -165,7 +197,7 @@ mod tests {
         assert_eq!(d.message_id(), "def");
     }
 
-    fn function_with_impl_arg(a: &impl ReplyToMessage) -> String {
+    fn function_with_impl_arg(a: &impl ReplyToMessage) -> FastStr {
         a.message_id().to_owned()
     }
 

--- a/src/transport/tcp.rs
+++ b/src/transport/tcp.rs
@@ -200,8 +200,8 @@ impl<C: MakeConnection> Transport for TCPTransport<C> {
 
         let message_sink =
             FramedWrite::new(write_half, BytesCodec::new()).with(move |msg: IRCMessage| {
-                let mut s = msg.as_raw_irc();
-                s.push_str("\r\n");
+                let s = msg.as_raw_irc();
+                let s = format!("{}{}", s, "\r\n");
                 future::ready(Ok(Bytes::from(s)))
             });
 


### PR DESCRIPTION
Replaced Strings type with FastStr, removed a lot of `to_owned()`, some autoformatting.

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable