### PR TITLE
fix(parsing): SubMysteryGift missing tag during SUBtember

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
 
 ## v4.1.0
 
-- Minor: Mark `ban`, `unban`, `timeout` and `untimeout` methods as deprecated (Due to Twitch removing support for these commands on 2023-02-18: https://discuss.dev.twitch.tv/t/deprecation-of-chat-commands-through-irc/40486) (#181)
+- Minor: Mark `ban`, `unban`, `timeout` and `untimeout` methods as deprecated (Due to Twitch removing support for these commands on 2023-02-18: <https://discuss.dev.twitch.tv/t/deprecation-of-chat-commands-through-irc/40486>) (#181)
 
 ## v4.0.0
 
@@ -83,9 +83,9 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
 
 ## v3.0.0
 
-- Breaking: Transports were refactored slightly:  
-  Renamed `twitch_irc::TCPTransport` to `SecureTCPTransport`, added `PlainTCPTransport` for plain-text IRC connections.  
-  Renamed `twitch_irc::WSSTransport` to `SecureWSTransport`, added `PlainWSTransport` for plain-text IRC-over-WebSocket-connections.  
+- Breaking: Transports were refactored slightly:
+  Renamed `twitch_irc::TCPTransport` to `SecureTCPTransport`, added `PlainTCPTransport` for plain-text IRC connections.
+  Renamed `twitch_irc::WSSTransport` to `SecureWSTransport`, added `PlainWSTransport` for plain-text IRC-over-WebSocket-connections.
   Refactored feature flags: This crate used to only have the `transport-tcp` and `transport-wss` feature flags. The following is the new list of feature flags relevant to transports:
   - `transport-tcp` enables `PlainTCPTransport`
   - `transport-tcp-native-tls` enables `SecureTCPTransport` using OS-native TLS functionality (and using the root certificates configured in your operating system).
@@ -94,7 +94,7 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
   - `transport-ws` (notice this is now `ws` instead of `wss`) - Enables `PlainWSTransport`
   - `transport-ws-native-tls` - Enables `SecureWSTransport` using native TLS (same as above)
   - `transport-ws-rustls-webpki-roots` - Enables `SecureWSTransport` using rustls with Mozilla's root certificates (same as above)
-  
+
   Some accompanying items have also been made `pub` in the crate.
 - Breaking: Updated `metrics` to version 0.16.
 - Minor: Added `timeout`, `untimeout`, `ban` and `unban` methods to `TwitchIRCClient` (#110)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,13 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
 - Breaking: Removed `ban()`, `unban()`, `timeout()` and `untimeout()` since they are no longer supported by Twitch.
   They were previously deprecated in v4.1.0 (#197)
 - Breaking: Fixed typo in RoomStateMessage's follower mode (was `follwers_only`, is now `followers_only`. (#200)
+- Breaking: `SubMysteryGift::sender_total_gifts` is now an `Option` because the tag is missing
+  when Twitch gift subs during SUBtember (#215)
 - Minor: Added support for reply-parent tags (#189)
 - Minor: Tokens in `CredentialsPair` and `UserAccessToken` are now redacted in their `Debug` output. Same
   applies to the `client_secret` in `RefreshingLoginCredentials`. (#199)
 - Minor: Added example demonstrating usage of `metrics-collection` feature as well as an exemplary grafana
   dashboard template. (#203, #208)
-- Minor: Fixed missing tag durring SUBtember (#215)
 
 ## v5.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
   applies to the `client_secret` in `RefreshingLoginCredentials`. (#199)
 - Minor: Added example demonstrating usage of `metrics-collection` feature as well as an exemplary grafana
   dashboard template. (#203, #208)
+- Minor: Fixed missing tag durring SUBtember (#215)
 
 ## v5.0.1
 

--- a/src/message/commands/usernotice.rs
+++ b/src/message/commands/usernotice.rs
@@ -209,15 +209,7 @@ pub enum UserNoticeEvent {
 
     /// This event precedes a wave of `subgift`/`anonsubgift` messages.
     /// (`<User> is gifting <mass_gift_count> Tier 1 Subs to <Channel>'s community! They've gifted a total of <sender_total_gifts> in the channel!`)
-    ///
-    /// This event combines `submysterygift` and `anonsubmysterygift`. In case of
-    /// `anonsubmysterygift` the sending user of the `USERNOTICE` carries no useful information,
-    /// it can be e.g. the channel owner or a service user like `AnAnonymousGifter`. You should
-    /// always check for `is_sender_anonymous` before using the sender of the `USERNOTICE`.
     SubMysteryGift {
-        /// Indicates whether the user sending this `USERNOTICE` is a dummy or a real gifter.
-        /// If this is `true` the gift comes from an anonymous user, and the user sending the
-        /// `USERNOTICE` carries no useful information and should be ignored.
         /// Number of gifts the sender just gifted.
         mass_gift_count: u64,
         /// Total number of gifts the sender has gifted in this channel. This includes the


### PR DESCRIPTION
- Tag `msg-param-sender-count` is missing during (some?) promotions
- Only seen with sender twitch, therefore handled as an edge case
- If sent by twitch and the tag is missing, then assume u64::MAX


Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable